### PR TITLE
Change canonical link for Simple Made Easy

### DIFF
--- a/Hickey_Rich/SimpleMadeEasy.md
+++ b/Hickey_Rich/SimpleMadeEasy.md
@@ -2,7 +2,7 @@
 
 * **Speaker: Rich Hickey**
 * **Conference: [Strange Loop 2011](http://thestrangeloop.com) - Sept 2011**
-* **Video: [http://www.infoq.com/presentations/Simple-Made-Easy](http://www.infoq.com/presentations/Simple-Made-Easy)**
+* **Video: [https://www.youtube.com/watch?v=SxdOUGdseq4](https://www.youtube.com/watch?v=SxdOUGdseq4)**
 
 ![00:00:00 Simple Made Easy](SimpleMadeEasy/00.00.00.jpg)
 


### PR DESCRIPTION
Recently I did a fresh edit from better source video and the original slides and this should be considered the new canonical source for the Simple Made Easy video.