### PR TITLE
Update link for "Inside core.async channels"

### DIFF
--- a/Hickey_Rich/ImplementationDetails.md
+++ b/Hickey_Rich/ImplementationDetails.md
@@ -2,7 +2,7 @@
 
 * **Speaker: Rich Hickey**
 * **Conference: [EuroClojure](http://euroclojure.com/2014/) - June 2014**
-* **Video: [https://vimeo.com/100518968](https://vimeo.com/100518968)**
+* **Video: [https://www.youtube.com/watch?v=hMEX6lfBeRM](https://www.youtube.com/watch?v=hMEX6lfBeRM)**
 
 ![00.00.00 Inside](ImplementationDetails/00.00.00.jpg)
 


### PR DESCRIPTION
I recently did a fresh edit of this talk that integrates the slides and has much more listenable audio. The updated link should now be considered the canonical version of this talk.